### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/wardslw/91e4d4bd-cfaa-438e-84af-41065a200f0c/8b674f00-6228-494c-a85a-ef824d9d7d5a/_apis/work/boardbadge/c9189cb9-3c69-40fe-ab58-a48ffc4ba100)](https://dev.azure.com/wardslw/91e4d4bd-cfaa-438e-84af-41065a200f0c/_boards/board/t/8b674f00-6228-494c-a85a-ef824d9d7d5a/Microsoft.RequirementCategory)
 # actions-test
 
 Fixed.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/wardslw/91e4d4bd-cfaa-438e-84af-41065a200f0c/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.